### PR TITLE
APPLAT-1370 fix empty body in retried responses

### DIFF
--- a/service/client.go
+++ b/service/client.go
@@ -140,7 +140,6 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 func (c *Client) onUnauthorizedRequest(req *http.Request) (*http.Response, error) {
 	// refresh and retry request here
 	httpMethod := req.Method
-	body := req.Body
 
 	//Refresh access token with refresh token
 	var accessToken string
@@ -151,6 +150,7 @@ func (c *Client) onUnauthorizedRequest(req *http.Request) (*http.Response, error
 	}
 	// Update the client with the newly obtained access token
 	c.UpdateToken(accessToken)
+	body, err := req.GetBody()
 	request, err := http.NewRequest(httpMethod, req.URL.String(), body)
 	if err != nil {
 		return nil, err

--- a/test/playground_integration/refresh_token_integration_test.go
+++ b/test/playground_integration/refresh_token_integration_test.go
@@ -9,26 +9,29 @@ import (
 	"github.com/splunk/ssc-client-go/service"
 	"github.com/splunk/ssc-client-go/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/splunk/ssc-client-go/model"
 )
 
 //Expired token
 var TestAuthenticationToken = os.Getenv("EXPIRED_BEARER_TOKEN")
 
-// CRUD tenant and add/delete user to the tenant
+//Test ingesting event with invalid access token then retrying after refreshing token
 func TestIntegrationRefreshTokenWorkflow(t *testing.T) {
 	var url = testutils.TestURLProtocol + "://" + testutils.TestSSCHost
-	client, _ := service.NewClient(testutils.TestTenantID, TestAuthenticationToken, url, testutils.TestTimeOut)
-	testTenantID := testutils.TestTenantID
-	//get user profile
-	user, err := client.IdentityService.GetUserProfile(testTenantID)
-	if err != nil {
-		t.FailNow()
-	}
-	assert.Nil(t, err)
-	assert.Equal(t, "test1@splunk.com", user.ID)
-	assert.Equal(t, "test1@splunk.com", user.Email)
-	assert.Equal(t, "Test1", user.FirstName)
-	assert.Equal(t, "Splunk", user.LastName)
-	assert.Equal(t, "Test1 Splunk", user.Name)
-	assert.Equal(t, "en-US", user.Locale)
+	client, err := service.NewClient(testutils.TestTenantID, TestAuthenticationToken, url, testutils.TestTimeOut)
+
+	assert.Emptyf(t, err, "Error initializing client: %s", err)
+
+	timeValue := float64(1529945178)
+	testHecEvent := model.HecEvent{
+		Host:       client.URL.RequestURI(),
+		Index:      "main",
+		Event:      "refreshtokentest",
+		Sourcetype: "sourcetype:refreshtokentest",
+		Source:     "manual-events",
+		Time:       &timeValue,
+		Fields:     map[string]string{"testKey": "testValue"}}
+
+	err = client.HecService.CreateEvent(testHecEvent)
+	assert.Emptyf(t, err, "Error ingesting test event using refresh logic: %s", err)
 }


### PR DESCRIPTION
The fix ended up being much easier than anticipated, there is a GetBody() method to return a copy of the body after it has been read that is now used.