### PR TITLE
Update tests to reflect kvstore bug fixes for the `collection` and `query` enpoints.

### DIFF
--- a/test/playground_integration/kvstore_collections_integration_test.go
+++ b/test/playground_integration/kvstore_collections_integration_test.go
@@ -271,7 +271,6 @@ func TestKVStoreCollectionsListRecordsCountValidInput(t *testing.T) {
 	assert.Len(t, recordsAfterInsert, 1)
 }
 
-// BUG! This should fail, but it doesn't because the kvstore service is not checking its input
 func TestKVStoreCollectionsListRecordsCountNegativeOutOfBoundsInput(t *testing.T) {
 	filters := map[string][]string{
 		"count": {"-1"},
@@ -301,9 +300,9 @@ func TestKVStoreCollectionsListRecordsCountNegativeOutOfBoundsInput(t *testing.T
 	assert.Len(t, createRecordTwoResponseMap, 1)
 
 	recordsAfterInsert, err := getClient(t).KVStoreService.ListRecords(testutils.TestNamespace, testutils.TestCollection, filters)
-	// BUG: This should return an error from the API instead of being successful
-	assert.NotNil(t, recordsAfterInsert)
-	assert.Nil(t, err)
+
+	assert.Nil(t, recordsAfterInsert)
+	assert.NotNil(t, err)
 }
 
 func TestKVStoreCollectionsListRecordsCountPositiveOutOfBoundsInput(t *testing.T) {
@@ -377,7 +376,6 @@ func TestKVStoreCollectionsListRecordsOffsetValidInput(t *testing.T) {
 	assert.Len(t, recordsAfterInsert, 1)
 }
 
-// BUG! This should fail, but it doesn't because the kvstore service is not checking its input
 func TestKVStoreCollectionsListRecordsOffsetNegativeOutOfBoundsInput(t *testing.T) {
 	filters := map[string][]string{
 		"offset": {"-1"},
@@ -407,9 +405,9 @@ func TestKVStoreCollectionsListRecordsOffsetNegativeOutOfBoundsInput(t *testing.
 	assert.Len(t, createRecordTwoResponseMap, 1)
 
 	recordsAfterInsert, err := getClient(t).KVStoreService.ListRecords(testutils.TestNamespace, testutils.TestCollection, filters)
-	// BUG: This should return an error from the API instead of being successful
-	assert.NotNil(t, recordsAfterInsert)
-	assert.Nil(t, err)
+
+	assert.Nil(t, recordsAfterInsert)
+	assert.NotNil(t, err)
 }
 
 func TestKVStoreCollectionsListRecordsOffsetPositiveOutOfBoundsInput(t *testing.T) {

--- a/test/playground_integration/kvstore_query_integration_test.go
+++ b/test/playground_integration/kvstore_query_integration_test.go
@@ -235,7 +235,6 @@ func TestKVStoreQueryCountValidInput(t *testing.T) {
 	assert.Len(t, recordsAfterInsert, 1)
 }
 
-// BUG! This should fail, but it doesn't because the kvstore service is not checking its input
 func TestKVStoreQueryCountNegativeOutOfBoundsInput(t *testing.T) {
 	filters := map[string][]string{
 		"count": {"-1"},
@@ -265,9 +264,9 @@ func TestKVStoreQueryCountNegativeOutOfBoundsInput(t *testing.T) {
 	assert.Len(t, createRecordTwoResponseMap, 1)
 
 	recordsAfterInsert, err := getClient(t).KVStoreService.QueryRecords(testutils.TestNamespace, testutils.TestCollection, filters)
-	// BUG: This should return an error from the API instead of being successful
-	assert.NotNil(t, recordsAfterInsert)
-	assert.Nil(t, err)
+
+	assert.Nil(t, recordsAfterInsert)
+	assert.NotNil(t, err)
 }
 
 func TestKVStoreQueryCountPositiveOutOfBoundsInput(t *testing.T) {
@@ -341,7 +340,6 @@ func TestKVStoreQueryOffsetValidInput(t *testing.T) {
 	assert.Len(t, recordsAfterInsert, 1)
 }
 
-// BUG! This should fail, but it doesn't because the kvstore service is not checking its input
 func TestKVStoreQueryOffsetNegativeOutOfBoundsInput(t *testing.T) {
 	filters := map[string][]string{
 		"offset": {"-1"},
@@ -371,9 +369,9 @@ func TestKVStoreQueryOffsetNegativeOutOfBoundsInput(t *testing.T) {
 	assert.Len(t, createRecordTwoResponseMap, 1)
 
 	recordsAfterInsert, err := getClient(t).KVStoreService.QueryRecords(testutils.TestNamespace, testutils.TestCollection, filters)
-	// BUG: This should return an error from the API instead of being successful
-	assert.NotNil(t, recordsAfterInsert)
-	assert.Nil(t, err)
+
+	assert.Nil(t, recordsAfterInsert)
+	assert.NotNil(t, err)
 }
 
 func TestKVStoreQueryOffsetPositiveOutOfBoundsInput(t *testing.T) {


### PR DESCRIPTION
Changed `TestKVStoreCollectionsListRecordsCountNegativeOutOfBoundsInput` to match bug fix changes from kvstore so that these fail correctly now.
Changed `TestKVStoreCollectionsListRecordsOffsetNegativeOutOfBoundsInput` to match bug fix changes from kvstore so that these fail correctly now.
Changed `TestKVStoreQueryCountNegativeOutOfBoundsInput` to match bug fix changes from kvstore so that these fail correctly now.
Changed `TestKVStoreQueryCountPositiveOutOfBoundsInput` to match bug fix changes from kvstore so that these fail correctly now.