### PR TITLE
Initialised callbackFunc to nil

### DIFF
--- a/service/client.go
+++ b/service/client.go
@@ -379,6 +379,7 @@ func (c *Client) NewBatchEventsSenderWithMaxAllowedError(batchSize int, interval
 		ErrorChan:        errorChan,
 		IsRunning:        false,
 		chanWaitInMilSec: 300,
+		callbackFunc:     nil,
 	}
 
 	return batchEventsSender, nil


### PR DESCRIPTION
The tests pass as before. Consumer is encountering the error on CI/CD pipeline during deployment over last few days. Have suggested the consumer to initialize callbackFunc to nil at their end as well and test if this resolves the issue. We are not entirely sure if this solves their problem but it's good to have this change as this initialization was missing. 