### PR TITLE
Ensure that errors are returned for all response handlers

### DIFF
--- a/service/client.go
+++ b/service/client.go
@@ -205,6 +205,9 @@ func (c *Client) Do(req *Request) (*http.Response, error) {
 	}
 	for _, hr := range c.responseHandlers {
 		response, err = hr.HandleResponse(c, req, response)
+		if err != nil {
+			return response, err
+		}
 	}
 	return response, err
 }

--- a/test/playground_integration/client_integration_test.go
+++ b/test/playground_integration/client_integration_test.go
@@ -6,10 +6,14 @@
 package playgroundintegration
 
 import (
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/splunk/ssc-client-go/service"
 	"github.com/splunk/ssc-client-go/testutils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,4 +39,39 @@ func getInvalidClient(t *testing.T) *service.Client {
 	client, err := service.NewClient(&service.Config{Token: testutils.TestAuthenticationToken, URL: url, TenantID: testutils.TestInvalidTestTenantID, Timeout: testutils.TestTimeOut})
 	require.Emptyf(t, err, "Error calling service.NewClient(): %s", err)
 	return client
+}
+
+type noOpHandler struct {
+	N int
+}
+
+func (rh *noOpHandler) HandleResponse(client *service.Client, request *service.Request, response *http.Response) (*http.Response, error) {
+	rh.N++
+	return response, nil
+}
+
+const rHandlerErrMsg = "my custom response handler error"
+
+type rHandlerErr struct {
+	N int
+}
+
+func (rh *rHandlerErr) HandleResponse(client *service.Client, request *service.Request, response *http.Response) (*http.Response, error) {
+	rh.N++
+	return nil, fmt.Errorf(rHandlerErrMsg)
+}
+
+func TestClientMultipleResponseHandlers(t *testing.T) {
+	var url = testutils.TestURLProtocol + "://" + testutils.TestSSCHost
+	var handler1 = &noOpHandler{}
+	var handler2 = &rHandlerErr{}
+	var handler3 = &noOpHandler{}
+	var handlers = []service.ResponseHandler{handler1, handler2, handler3}
+	client, err := service.NewClient(&service.Config{Token: testutils.TestAuthenticationToken, URL: url, TenantID: testutils.TestInvalidTestTenantID, Timeout: testutils.TestTimeOut, ResponseHandlers: handlers})
+	require.Nil(t, err, "Error calling service.NewClient(): %s", err)
+	_, err = client.SearchService.GetJobs(nil)
+	assert.True(t, strings.Contains(err.Error(), rHandlerErrMsg), "error should match custom error from response handler")
+	assert.Equal(t, handler1.N, 1, "first handler should have been called")
+	assert.Equal(t, handler2.N, 1, "second (error) handler should have been called")
+	assert.Equal(t, handler3.N, 0, "third handler should not have been called")
 }


### PR DESCRIPTION
And subsequent response handlers are not called.

This was missed in the IDP rework.