### PR TITLE
Applat 2723 fix the failing catalog and streams integration tests

### DIFF
--- a/test/playground_integration/identity_integration_test.go
+++ b/test/playground_integration/identity_integration_test.go
@@ -195,8 +195,17 @@ func TestCRUDMembers(t *testing.T) {
 	assert.Equal(t, memberName, result2.Name)
 	assert.Equal(t, testutils.TestTenant, result2.Tenant)
 
+	groupName := fmt.Sprintf("grouptest%d", timeSec)
+
+	// create a group
+	resultgroup, err := client.IdentityService.CreateGroup(groupName)
+	defer client.IdentityService.DeleteGroup(groupName)
+	require.Nil(t, err)
+	assert.Equal(t, groupName, resultgroup.Name)
+	assert.Equal(t, "test1@splunk.com", resultgroup.CreatedBy)
+	assert.Equal(t, testutils.TestTenant, resultgroup.Tenant)
+
 	// add member to group
-	groupName := "users" //pre-defined group
 	result3, err := client.IdentityService.AddMemberToGroup(groupName, memberName)
 	defer client.IdentityService.RemoveGroupMember(groupName, memberName)
 	require.Nil(t, err)
@@ -207,7 +216,25 @@ func TestCRUDMembers(t *testing.T) {
 	assert.Equal(t, 1, len(result4))
 	assert.Contains(t, result4, groupName)
 
-	roleName := "user" //pre-defind role
+	// group-role
+	roleName := fmt.Sprintf("grouptestrole%d", timeSec)
+
+	// create a test role
+	resultrole, err := client.IdentityService.CreateRole(roleName)
+	defer client.IdentityService.DeleteRole(roleName)
+	require.Nil(t, err)
+	assert.Equal(t, roleName, resultrole.Name)
+	assert.Equal(t, "test1@splunk.com", resultrole.CreatedBy)
+	assert.Equal(t, testutils.TestTenant, resultrole.Tenant)
+
+	// add role to group
+	resultrole1, err := client.IdentityService.AddRoleToGroup(groupName, roleName)
+	defer client.IdentityService.RemoveGroupRole(groupName, roleName)
+	require.Nil(t, err)
+	assert.Equal(t, roleName, resultrole1.Role)
+	assert.Equal(t, groupName, resultrole1.Group)
+	assert.Equal(t, testutils.TestTenant, resultrole1.Tenant)
+
 	result5, err := client.IdentityService.GetMemberRoles(memberName)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(result5))
@@ -221,7 +248,7 @@ func TestCRUDMembers(t *testing.T) {
 	assert.Equal(t, roleName, result6.Role)
 	assert.Equal(t, permissionName, result6.Permission)
 
-	permissionName1 := fmt.Sprintf("%v:users:identity.groups.read", testutils.TestTenant)
+	permissionName1 := fmt.Sprintf("%v:%v:identity.groups.read", testutils.TestTenant, groupName)
 	permissionName2 := fmt.Sprintf("%v:%v:identity.members.read", testutils.TestTenant, memberName)
 	result7, err := client.IdentityService.GetMemberPermissions(memberName)
 	require.Nil(t, err)
@@ -230,7 +257,7 @@ func TestCRUDMembers(t *testing.T) {
 	assert.Contains(t, result7, permissionName1)
 	assert.Contains(t, result7, permissionName2)
 
-	// delete
+	// delete the test member
 	err = client.IdentityService.RemoveMember(memberName)
 	require.Nil(t, err)
 }


### PR DESCRIPTION
The newly created tenants now have just one default group 'tenant.admins'. 'Users' is no longer a default group. Created a test group and a test role to fix the failing 'CRUDMembers' test.