### PR TITLE
BLOCKED BY #282: Update CI Dockerfile to go 1.11

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,5 +1,5 @@
 # Starting from the latest Golang image
-FROM golang:1.9.4-alpine
+FROM golang:1.11-alpine
 
 # INSTALL any further tools you need here so they are cached in the docker build
 ENV DEP_VERSION=0.4.1

--- a/test/integration/search_integration_test.go
+++ b/test/integration/search_integration_test.go
@@ -177,7 +177,7 @@ func TestCreateJobConfigurableBackOffRetry(t *testing.T) {
 		Host:          testutils.TestSplunkCloudHost,
 		Tenant:        testutils.TestTenant,
 		RetryRequests: true,
-		RetryConfig:   services.RetryStrategyConfig{nil, &services.ConfigurableRetryConfig{5, 600}},
+		RetryConfig:   services.RetryStrategyConfig{ConfigurableRetryConfig: &services.ConfigurableRetryConfig{RetryNum: 5, Interval: 600}},
 	})
 
 	var cnt int
@@ -199,7 +199,7 @@ func TestCreateJobDefaultBackOffRetry(t *testing.T) {
 		Host:          testutils.TestSplunkCloudHost,
 		Tenant:        testutils.TestTenant,
 		RetryRequests: true,
-		RetryConfig:   services.RetryStrategyConfig{&services.DefaultRetryConfig{}, nil},
+		RetryConfig:   services.RetryStrategyConfig{DefaultRetryConfig: &services.DefaultRetryConfig{}},
 	})
 
 	var cnt int


### PR DESCRIPTION
Also fix go vet issues unique to 1.11