### PR TITLE
Create and cleanup models on a per-test-run basis

### DIFF
--- a/test/integration/action_integration_test.go
+++ b/test/integration/action_integration_test.go
@@ -253,7 +253,7 @@ func TestGetActionStatus(t *testing.T) {
 	webhookAction := model.NewWebhookAction(webhookActionName, webhookURL, webhookMsg)
 	action, err := client.ActionService.CreateAction(*webhookAction)
 	require.Nil(t, err)
-	defer cleanupAction(client, webhookAction.Name) // TODO: Tim
+	defer cleanupAction(client, webhookAction.Name)
 	require.NotNil(t, action)
 	resp, err := client.ActionService.TriggerAction(webhookAction.Name,
 		model.ActionNotification{
@@ -274,9 +274,9 @@ func TestTriggerActionTenantMismatch(t *testing.T) {
 	client := getSdkClient(t)
 	webhookActionName := fmt.Sprintf("w_badten_%d", testutils.TimeSec)
 	webhookAction := model.NewWebhookAction(webhookActionName, webhookURL, webhookMsg)
-	defer cleanupAction(client, webhookAction.Name)
 	action, err := client.ActionService.CreateAction(*webhookAction)
 	require.Nil(t, err)
+	defer cleanupAction(client, webhookAction.Name)
 	require.NotNil(t, action)
 	_, err = client.ActionService.TriggerAction(webhookAction.Name,
 		model.ActionNotification{

--- a/test/integration/client_integration_test.go
+++ b/test/integration/client_integration_test.go
@@ -154,8 +154,8 @@ func TestRoundTripperWithSdkClient(t *testing.T) {
 	webhookActionName := "testaction"
 	webhookAction := model.NewWebhookAction(webhookActionName, webhookURL, webhookMsg)
 	action, err := client.ActionService.CreateAction(*webhookAction)
-	defer client.ActionService.DeleteAction(webhookActionName)
 	require.Nil(t, err)
+	defer client.ActionService.DeleteAction(webhookActionName)
 	require.NotEmpty(t, action)
 	assert.Equal(t, 2, len(LoggerOutput))
 

--- a/test/integration/identity_integration_test.go
+++ b/test/integration/identity_integration_test.go
@@ -34,16 +34,15 @@ func TestIdentityClientInit(t *testing.T) {
 func TestCRUDGroups(t *testing.T) {
 	client := getClient(t)
 
-	res, err := client.IdentityService.GetGroups()
+	_, err := client.IdentityService.GetGroups()
 	require.Nil(t, err)
-	groupNum := len(res)
 
 	groupName := fmt.Sprintf("grouptest%d", testutils.TimeSec)
 
 	// create/get/delete group and groups
 	resultgroup, err := client.IdentityService.CreateGroup(groupName)
-	defer client.IdentityService.DeleteGroup(groupName)
 	require.Nil(t, err)
+	defer client.IdentityService.DeleteGroup(groupName)
 	assert.Equal(t, groupName, resultgroup.Name)
 	assert.Equal(t, testutils.TestUsername, resultgroup.CreatedBy)
 	assert.Equal(t, testutils.TestTenant, resultgroup.Tenant)
@@ -57,25 +56,23 @@ func TestCRUDGroups(t *testing.T) {
 
 	resultgroup2, err := client.IdentityService.GetGroups()
 	require.Nil(t, err)
-	assert.Equal(t, groupNum+2, len(resultgroup2))
 	assert.Contains(t, resultgroup2, groupName)
 
 	// group-roles
 	roleName := fmt.Sprintf("grouptestrole%d", testutils.TimeSec)
-	res2, err := client.IdentityService.GetGroupRoles(groupName)
+	_, err = client.IdentityService.GetGroupRoles(groupName)
 	require.Nil(t, err)
-	roleNum := len(res2)
 
 	resultrole, err := client.IdentityService.CreateRole(roleName)
-	defer client.IdentityService.DeleteRole(roleName)
 	require.Nil(t, err)
+	defer client.IdentityService.DeleteRole(roleName)
 	assert.Equal(t, roleName, resultrole.Name)
 	assert.Equal(t, testutils.TestUsername, resultrole.CreatedBy)
 	assert.Equal(t, testutils.TestTenant, resultrole.Tenant)
 
 	resultrole1, err := client.IdentityService.AddRoleToGroup(groupName, roleName)
-	defer client.IdentityService.RemoveGroupRole(groupName, roleName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveGroupRole(groupName, roleName)
 	assert.Equal(t, roleName, resultrole1.Role)
 	assert.Equal(t, groupName, resultrole1.Group)
 	assert.Equal(t, testutils.TestTenant, resultrole1.Tenant)
@@ -83,14 +80,12 @@ func TestCRUDGroups(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	resultrole2, err := client.IdentityService.GetGroupRoles(groupName)
 	require.Nil(t, err)
-	assert.Equal(t, roleNum+1, len(resultrole2))
 	assert.Contains(t, resultrole2, roleName)
 
 	//group-members
 	memberName := "test1@splunk.com"
-	res3, err := client.IdentityService.GetGroupMembers(groupName)
+	_, err = client.IdentityService.GetGroupMembers(groupName)
 	require.Nil(t, err)
-	memberNum := len(res3)
 
 	//add group member
 	_, err = client.IdentityService.AddMember(memberName)
@@ -98,8 +93,8 @@ func TestCRUDGroups(t *testing.T) {
 	defer client.IdentityService.RemoveMember(memberName)
 
 	resultmember1, err := client.IdentityService.AddMemberToGroup(groupName, memberName)
-	defer client.IdentityService.RemoveGroupMember(groupName, memberName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveGroupMember(groupName, memberName)
 	assert.Equal(t, memberName, resultmember1.Principal)
 	assert.Equal(t, groupName, resultmember1.Group)
 	assert.Equal(t, testutils.TestTenant, resultmember1.Tenant)
@@ -107,7 +102,6 @@ func TestCRUDGroups(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	resultmember2, err := client.IdentityService.GetGroupMembers(groupName)
 	require.Nil(t, err)
-	assert.Equal(t, memberNum+1, len(resultmember2))
 	assert.Contains(t, resultmember2, memberName)
 
 	resultmember3, err := client.IdentityService.GetGroupMember(groupName, memberName)
@@ -131,16 +125,15 @@ func TestCRUDGroups(t *testing.T) {
 func TestCRUDRoles(t *testing.T) {
 	client := getClient(t)
 
-	res, err := client.IdentityService.GetRoles()
+	_, err := client.IdentityService.GetRoles()
 	require.Nil(t, err)
-	roleNum := len(res)
 
 	roleName := fmt.Sprintf("roletest%d", testutils.TimeSec)
 
 	// create/get/delete role and roles
 	resultrole, err := client.IdentityService.CreateRole(roleName)
-	defer client.IdentityService.DeleteRole(roleName)
 	require.Nil(t, err)
+	defer client.IdentityService.DeleteRole(roleName)
 	assert.Equal(t, roleName, resultrole.Name)
 	assert.Equal(t, testutils.TestUsername, resultrole.CreatedBy)
 	assert.Equal(t, testutils.TestTenant, resultrole.Tenant)
@@ -154,18 +147,16 @@ func TestCRUDRoles(t *testing.T) {
 
 	resultrole2, err := client.IdentityService.GetRoles()
 	require.Nil(t, err)
-	assert.Equal(t, roleNum+2, len(resultrole2))
 	assert.Contains(t, resultrole2, roleName)
 
 	// role-permissions
 	permissionName := fmt.Sprintf("perm1-%d", testutils.TimeSec)
-	result1, err := client.IdentityService.GetRolePermissions(roleName)
+	_, err = client.IdentityService.GetRolePermissions(roleName)
 	require.Nil(t, err)
-	permNum := len(result1)
 
 	resultroleperm, err := client.IdentityService.AddPermissionToRole(roleName, permissionName)
-	defer client.IdentityService.RemoveRolePermission(roleName, permissionName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveRolePermission(roleName, permissionName)
 	assert.Equal(t, roleName, resultroleperm.Role)
 	assert.Equal(t, permissionName, resultroleperm.Permission)
 	assert.Equal(t, testutils.TestUsername, resultroleperm.AddedBy)
@@ -181,7 +172,6 @@ func TestCRUDRoles(t *testing.T) {
 
 	resultroleperm2, err := client.IdentityService.GetRolePermissions(roleName)
 	require.Nil(t, err)
-	assert.Equal(t, permNum+1, len(resultroleperm2))
 	assert.Contains(t, resultroleperm2, permissionName)
 
 	// delete
@@ -194,23 +184,21 @@ func TestCRUDRoles(t *testing.T) {
 func TestCRUDMembers(t *testing.T) {
 	client := getClient(t)
 
-	res, err := client.IdentityService.GetMembers()
+	_, err := client.IdentityService.GetMembers()
 	require.Nil(t, err)
-	memNum := len(res)
 
 	memberName := "test1@splunk.com"
 
 	// create/get/delete member and members
 	result, err := client.IdentityService.AddMember(memberName)
-	defer client.IdentityService.RemoveMember(memberName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveMember(memberName)
 	assert.Equal(t, memberName, result.Name)
 	assert.Equal(t, testutils.TestTenant, result.Tenant)
 
 	time.Sleep(2 * time.Second)
 	result1, err := client.IdentityService.GetMembers()
 	require.Nil(t, err)
-	assert.Equal(t, memNum+1, len(result1))
 	assert.Contains(t, result1, memberName)
 
 	result2, err := client.IdentityService.GetMember(memberName)
@@ -222,22 +210,21 @@ func TestCRUDMembers(t *testing.T) {
 
 	// create a group
 	resultgroup, err := client.IdentityService.CreateGroup(groupName)
-	defer client.IdentityService.DeleteGroup(groupName)
 	require.Nil(t, err)
+	defer client.IdentityService.DeleteGroup(groupName)
 	assert.Equal(t, groupName, resultgroup.Name)
 	assert.Equal(t, testutils.TestUsername, resultgroup.CreatedBy)
 	assert.Equal(t, testutils.TestTenant, resultgroup.Tenant)
 
 	// add member to group
 	result3, err := client.IdentityService.AddMemberToGroup(groupName, memberName)
-	defer client.IdentityService.RemoveGroupMember(groupName, memberName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveGroupMember(groupName, memberName)
 	assert.Equal(t, groupName, result3.Group)
 
 	time.Sleep(2 * time.Second)
 	result4, err := client.IdentityService.GetMemberGroups(memberName)
 	require.Nil(t, err)
-	assert.Equal(t, 1, len(result4))
 	assert.Contains(t, result4, groupName)
 
 	// group-role
@@ -245,16 +232,16 @@ func TestCRUDMembers(t *testing.T) {
 
 	// create a test role
 	resultrole, err := client.IdentityService.CreateRole(roleName)
-	defer client.IdentityService.DeleteRole(roleName)
 	require.Nil(t, err)
+	defer client.IdentityService.DeleteRole(roleName)
 	assert.Equal(t, roleName, resultrole.Name)
 	assert.Equal(t, testutils.TestUsername, resultrole.CreatedBy)
 	assert.Equal(t, testutils.TestTenant, resultrole.Tenant)
 
 	// add role to group
 	resultrole1, err := client.IdentityService.AddRoleToGroup(groupName, roleName)
-	defer client.IdentityService.RemoveGroupRole(groupName, roleName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveGroupRole(groupName, roleName)
 	assert.Equal(t, roleName, resultrole1.Role)
 	assert.Equal(t, groupName, resultrole1.Group)
 	assert.Equal(t, testutils.TestTenant, resultrole1.Tenant)
@@ -262,14 +249,13 @@ func TestCRUDMembers(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	result5, err := client.IdentityService.GetMemberRoles(memberName)
 	require.Nil(t, err)
-	assert.Equal(t, 1, len(result5))
 	assert.Contains(t, result5, roleName)
 
 	// add permission to role
 	permissionName := "myperm"
 	result6, err := client.IdentityService.AddPermissionToRole(roleName, permissionName)
-	defer client.IdentityService.RemoveRolePermission(roleName, permissionName)
 	require.Nil(t, err)
+	defer client.IdentityService.RemoveRolePermission(roleName, permissionName)
 	assert.Equal(t, roleName, result6.Role)
 	assert.Equal(t, permissionName, result6.Permission)
 
@@ -278,7 +264,6 @@ func TestCRUDMembers(t *testing.T) {
 	permissionName2 := fmt.Sprintf("%v:%v:identity.members.read", testutils.TestTenant, memberName)
 	result7, err := client.IdentityService.GetMemberPermissions(memberName)
 	require.Nil(t, err)
-	assert.Equal(t, 6, len(result7))
 	assert.Contains(t, result7, permissionName)
 	assert.Contains(t, result7, permissionName1)
 	assert.Contains(t, result7, permissionName2)

--- a/test/integration/streams_integration_test.go
+++ b/test/integration/streams_integration_test.go
@@ -20,17 +20,17 @@ func TestIntegrationGetAllPipelines(t *testing.T) {
 	pipelineName2 := fmt.Sprintf("testPipeline02%d", testutils.TimeSec)
 
 	// Create two test pipelines
-	pipeline1, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName1, testPipelineDescription))
-	defer cleanupPipeline(getClient(t), pipeline1.ID, pipeline1.Name)
+	pipeline1, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName1, testPipelineDescription))
 	require.Nil(t, err)
+	defer cleanupPipeline(getClient(t), pipeline1.ID, pipeline1.Name)
 	require.NotEmpty(t, pipeline1)
 	assert.Equal(t, model.Created, pipeline1.Status)
 	assert.Equal(t, pipelineName1, pipeline1.Name)
 	assert.Equal(t, testPipelineDescription, pipeline1.Description)
 
-	pipeline2, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName2, testPipelineDescription))
-	defer cleanupPipeline(getClient(t), pipeline2.ID, pipeline2.Name)
+	pipeline2, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName2, testPipelineDescription))
 	require.Nil(t, err)
+	defer cleanupPipeline(getClient(t), pipeline2.ID, pipeline2.Name)
 	require.NotEmpty(t, pipeline2)
 	assert.Equal(t, model.Created, pipeline2.Status)
 	assert.Equal(t, pipelineName2, pipeline2.Name)
@@ -63,9 +63,9 @@ func TestIntegrationCreatePipeline(t *testing.T) {
 	pipelineName := fmt.Sprintf("testPipeline%d", testutils.TimeSec)
 
 	// Create a test pipeline and verify that the pipeline was created
-	pipeline, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName, testPipelineDescription))
-	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
+	pipeline, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName, testPipelineDescription))
 	require.Nil(t, err)
+	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
 	require.NotEmpty(t, pipeline)
 	assert.Equal(t, model.Created, pipeline.Status)
 	assert.Equal(t, pipelineName, pipeline.Name)
@@ -116,9 +116,9 @@ func TestIntegrationActivatePipeline(t *testing.T) {
 	pipelineName := fmt.Sprintf("testPipeline%d", testutils.TimeSec)
 
 	// Create a test pipeline
-	pipeline, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName, testPipelineDescription))
-	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
+	pipeline, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName, testPipelineDescription))
 	require.Nil(t, err)
+	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
 	require.NotEmpty(t, pipeline)
 	assert.Equal(t, model.Created, pipeline.Status)
 	assert.Equal(t, pipelineName, pipeline.Name)
@@ -147,9 +147,9 @@ func TestIntegrationDeactivatePipeline(t *testing.T) {
 	pipelineName := fmt.Sprintf("testPipeline%d", testutils.TimeSec)
 
 	// Create a test pipeline
-	pipeline, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName, testPipelineDescription))
-	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
+	pipeline, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName, testPipelineDescription))
 	require.Nil(t, err)
+	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
 	require.NotEmpty(t, pipeline)
 	assert.Equal(t, model.Created, pipeline.Status)
 	assert.Equal(t, pipelineName, pipeline.Name)
@@ -183,16 +183,16 @@ func TestIntegrationUpdatePipeline(t *testing.T) {
 	pipelineName := fmt.Sprintf("testPipeline%d", testutils.TimeSec)
 
 	// Create a test pipeline
-	pipeline, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName, testPipelineDescription))
-	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
+	pipeline, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName, testPipelineDescription))
 	require.Nil(t, err)
+	defer cleanupPipeline(getClient(t), pipeline.ID, pipeline.Name)
 	require.NotEmpty(t, pipeline)
 	assert.Equal(t, pipelineName, pipeline.Name)
 	assert.Equal(t, testPipelineDescription, pipeline.Description)
 
 	// Update the newly created test pipeline
 	updatedPipelineName := fmt.Sprintf("updated%v", pipelineName)
-	updatedPipeline, err := getClient(t).StreamsService.UpdatePipeline(pipeline.ID, CreatePipelineRequest(t, updatedPipelineName, "Updated Integration Test Pipeline"))
+	updatedPipeline, err := getClient(t).StreamsService.UpdatePipeline(pipeline.ID, makePipelineRequest(t, updatedPipelineName, "Updated Integration Test Pipeline"))
 	require.Nil(t, err)
 	require.NotEmpty(t, updatedPipeline)
 	assert.Equal(t, updatedPipelineName, updatedPipeline.Name)
@@ -205,7 +205,7 @@ func TestIntegrationDeletePipeline(t *testing.T) {
 	pipelineName := fmt.Sprintf("testPipeline%d", testutils.TimeSec)
 
 	// Create a test pipeline
-	pipeline, err := getClient(t).StreamsService.CreatePipeline(CreatePipelineRequest(t, pipelineName, testPipelineDescription))
+	pipeline, err := getClient(t).StreamsService.CreatePipeline(makePipelineRequest(t, pipelineName, testPipelineDescription))
 	require.Nil(t, err)
 	require.NotEmpty(t, pipeline)
 	assert.Equal(t, model.Created, pipeline.Status)
@@ -223,8 +223,8 @@ func TestIntegrationDeletePipeline(t *testing.T) {
 	require.Empty(t, pipeline)
 }
 
-// Creates a pipeline request
-func CreatePipelineRequest(t *testing.T, name string, description string) *model.PipelineRequest {
+// makePipelineRequest is a helper function to make a PipelineRequest model
+func makePipelineRequest(t *testing.T, name string, description string) *model.PipelineRequest {
 	// Create a test UPL JSON from a test DSL
 	var dsl = "kafka-brokers=\"localhost:9092\";input-topic = \"intopic\";output-topic-1 = \"output-topic-1\";events = deserialize-events(unauthenticated-read-kafka(kafka-brokers, input-topic, {}));unauthenticated-write-kafka(serialize-events(events, output-topic-1), kafka-brokers, {});"
 	result, err := getClient(t).StreamsService.CompileDslToUpl(&model.DslCompilationRequest{Dsl: dsl})


### PR DESCRIPTION
Most services are doing a great job of this already - the major changes are in the catalog refactor PR. This is just a followup to help some of the identity tests that were expecting a fixed number of groups (which wouldn't work if tests were running at the same time).

There are a few identity tests that involve adding `test1@splunk.com` as a member, performing some CRUD operations, then removing it as a member. This won't work with two tests running at the same time, but since members can't be created on the fly in SCP I don't really see a way around this.